### PR TITLE
Configure output plugin with checkpoint initialized to newest/oldest message in queue

### DIFF
--- a/src/hs_analysis_plugins.c
+++ b/src/hs_analysis_plugins.c
@@ -393,7 +393,8 @@ static void* input_thread(void *arg)
                              hs_input_dir,
                              at->input.name,
                              cfg->output_path,
-                             &at->input.cp);
+                             &at->input.cp,
+                             false);
   at->cp.id = at->input.cp.id;
   at->cp.offset = at->input.cp.offset;
   size_t discarded_bytes;

--- a/src/hs_checkpoint_reader.h
+++ b/src/hs_checkpoint_reader.h
@@ -68,7 +68,8 @@ void hs_lookup_input_checkpoint(hs_checkpoint_reader *cpr,
                                 const char *key,
                                 const char *path,
                                 const char *subdir,
-                                hs_checkpoint *cp);
+                                hs_checkpoint *cp,
+                                bool checkpoint_newest);
 
 void hs_update_input_checkpoint(hs_checkpoint_reader *cpr,
                                 const char *subdir,

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -55,6 +55,7 @@ static const char *cfg_sb_ticker_interval = "ticker_interval";
 static const char *cfg_sb_thread = "thread";
 static const char *cfg_sb_async_buffer = "async_buffer_size";
 static const char *cfg_sb_matcher = "message_matcher";
+static const char *cfg_sb_checkpoint_newest = "initial_checkpoint_newest";
 
 static void init_sandbox_config(hs_sandbox_config *cfg)
 {
@@ -70,6 +71,7 @@ static void init_sandbox_config(hs_sandbox_config *cfg)
   cfg->ticker_interval = 0;
   cfg->thread = 0;
   cfg->async_buffer_size = 0;
+  cfg->checkpoint_newest = false;
 }
 
 
@@ -391,6 +393,10 @@ bool hs_load_sandbox_config(const char *dir,
   if (type == 'o') {
     ret = get_numeric_item(L, LUA_GLOBALSINDEX, cfg_sb_async_buffer,
                            &cfg->async_buffer_size);
+    if (ret) goto cleanup;
+
+    ret = get_bool_item(L, LUA_GLOBALSINDEX, cfg_sb_checkpoint_newest,
+                        &cfg->checkpoint_newest);
     if (ret) goto cleanup;
   }
 

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -40,6 +40,7 @@ typedef struct hs_sandbox_config
   unsigned instruction_limit;
   unsigned ticker_interval;
   bool preserve_data;
+  bool checkpoint_newest;
 } hs_sandbox_config;
 
 typedef struct hs_config

--- a/src/hs_output_plugins.c
+++ b/src/hs_output_plugins.c
@@ -508,7 +508,8 @@ static void add_plugin(hs_output_plugins *plugins, hs_output_plugin *p, int idx)
 }
 
 static void add_to_output_plugins(hs_output_plugins *plugins,
-                                  hs_output_plugin *p)
+                                  hs_output_plugin *p,
+                                  bool checkpoint_newest)
 {
   bool added = false;
   int idx = -1;
@@ -552,7 +553,8 @@ static void add_to_output_plugins(hs_output_plugins *plugins,
                              hs_input_dir,
                              p->name,
                              cfg->output_path,
-                             &p->input.cp);
+                             &p->input.cp,
+                             checkpoint_newest);
   p->cur.input.id = p->cp.input.id = p->input.cp.id;
   p->cur.input.offset = p->cp.input.offset = p->input.cp.offset;
 
@@ -560,7 +562,8 @@ static void add_to_output_plugins(hs_output_plugins *plugins,
                              hs_analysis_dir,
                              p->name,
                              cfg->output_path,
-                             &p->analysis.cp);
+                             &p->analysis.cp,
+                             checkpoint_newest);
   p->cur.analysis.id = p->cp.analysis.id = p->analysis.cp.id;
   p->cur.analysis.offset = p->cp.analysis.offset = p->analysis.cp.offset;
 
@@ -732,7 +735,7 @@ void hs_load_output_plugins(hs_output_plugins *plugins, const hs_config *cfg,
                       p->name);
         hs_init_input(&p->analysis, cfg->max_message_size, cfg->output_path,
                       p->name);
-        add_to_output_plugins(plugins, p);
+        add_to_output_plugins(plugins, p, sbc.checkpoint_newest);
       } else {
         hs_log(NULL, g_module, 3, "%s create_output_plugin failed",
                sbc.cfg_name);


### PR DESCRIPTION
See #24.

> If no checkpoint exists
> e.g., initial_checkpoint = "oldest|newest" (defaulting to oldest, the current behaviour)