### PR TITLE
Add a clean shutdown option for input sandboxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,24 +3,24 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(hindsight VERSION 0.9.0 LANGUAGES C)
+project(hindsight VERSION 0.10.0 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hindsight")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(CPACK_PACKAGE_VENDOR        "Trink")
+set(CPACK_PACKAGE_VENDOR        "Mozilla Services")
 set(CPACK_PACKAGE_CONTACT       "Mike Trinkala <trink@mozilla.com>")
 set(CPACK_STRIP_FILES           TRUE)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
 set(CPACK_RPM_PACKAGE_LICENSE   "MPLv2.0")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "luasandbox (>= 1.0)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "luasandbox (>= 1.1)")
 
 set(PROJECT_PATH "${CMAKE_BINARY_DIR}/${PROJECT_NAME}")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-include(trink)
+include(mozsvc)
 
-find_package(luasandbox 1.0.3 REQUIRED CONFIG)
+find_package(luasandbox 1.1.0 REQUIRED CONFIG)
 include(GNUInstallDirs)
 
 if(CMAKE_HOST_UNIX)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Hindsight is that light weight skeleton around the same lua sandbox offering
 
 * Clang 3.1 or GCC 4.7+
 * CMake (3.0+) - http://cmake.org/cmake/resources/software.html
-* lua_sandbox (1.0.3+) - https://github.com/mozilla-services/lua_sandbox
+* lua_sandbox (1.1+) - https://github.com/mozilla-services/lua_sandbox
 
 ### CMake Build Instructions
 
-    git clone git@github.com:trink/hindsight.git
+    git clone git@github.com:mozilla-services/hindsight.git
     cd hindsight 
     mkdir release
     cd release

--- a/benchmarks/run/input/input_test.cfg
+++ b/benchmarks/run/input/input_test.cfg
@@ -1,4 +1,4 @@
 filename = "input_test.lua"
 instruction_limit = 0
-input_file = "/work/git/misc-heka/benchmark/access_msec.log"
+input_file = "access_msec.log"
 preserve_data = true

--- a/cmake/mozsvc.cmake
+++ b/cmake/mozsvc.cmake
@@ -13,7 +13,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS_DEBUG     "/MDd /Zi /RTC1")
 
     # multi threaded dll runtime, optimize for speed, auto inlining
-    set(CMAKE_C_FLAGS_RELEASE   "/MD /O2 /Ob2 /DNDEBUG")
+    set(CMAKE_C_FLAGS_RELEASE   "/MD /O2 /Ob2")
 
     set(CPACK_GENERATOR         "NSIS")
 else()

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,7 +4,7 @@ It is very preliminary but I setup a test using some Nginx logs. The logs were s
 1,002,646 log lines. The test consists of parsing the Nginx logs, converting them to a Heka protobuf stream, and writing 
 them back to disk.  The configurations were setup to be as equivalent as posssible (single output, similar flush 
 intervals, and individual readers for each file in the concurrent test). The configs can be found here: 
-https://github.com/trink/hindsight/tree/master/benchmarks.  
+https://github.com/mozilla-services/hindsight/tree/master/benchmarks.
 
 ### Test Hardware
 

--- a/src/hs_analysis_plugins.c
+++ b/src/hs_analysis_plugins.c
@@ -370,7 +370,6 @@ static void analyze_message(hs_analysis_thread *at, bool sample)
       bool matched = lsb_eval_message_matcher(p->mm, at->msg);
       if (sample) {
         lsb_update_running_stats(&p->mms, lsb_get_time() - start);
-        p->stats = lsb_heka_get_stats(p->hsb);
       }
       if (matched) {
         ret = lsb_heka_pm_analysis(p->hsb, at->msg, false);
@@ -381,6 +380,9 @@ static void analyze_message(hs_analysis_thread *at, bool sample)
           }
         }
       }
+    }
+    if (sample) {
+      p->stats = lsb_heka_get_stats(p->hsb);
     }
 
     if (ret <= 0 && p->ticker_interval && at->current_t >= p->ticker_expires) {

--- a/src/hs_checkpoint_writer.c
+++ b/src/hs_checkpoint_writer.c
@@ -111,7 +111,7 @@ void hs_write_checkpoints(hs_checkpoint_writer *cpw, hs_checkpoint_reader *cpr)
                   "%llu\t%llu\t%llu\t%llu\t"
                   "0\t0\t"
                   "%.0f\t%.0f\t"
-                  "%.0f\t%.0f\t\n",
+                  "%.0f\t%.0f\n",
                   p->name,
                   p->stats.im_cnt, p->stats.im_bytes,
                   p->stats.pm_cnt, p->stats.pm_failures,
@@ -170,7 +170,7 @@ void hs_write_checkpoints(hs_checkpoint_writer *cpw, hs_checkpoint_reader *cpr)
                   "%llu\t%llu\t%llu\t%llu\t"
                   "%.0f\t%.0f\t"
                   "%.0f\t%.0f\t"
-                  "%.0f\t%.0f\t\n",
+                  "%.0f\t%.0f\n",
                   p->name,
                   p->stats.im_cnt, p->stats.im_bytes,
                   p->stats.pm_cnt, p->stats.pm_failures,
@@ -216,7 +216,7 @@ void hs_write_checkpoints(hs_checkpoint_writer *cpw, hs_checkpoint_reader *cpr)
                 "%llu\t%llu\t%llu\t%llu\t"
                 "%.0f\t%.0f\t"
                 "%.0f\t%.0f\t"
-                "%.0f\t%.0f\t\n",
+                "%.0f\t%.0f\n",
                 p->name,
                 p->stats.im_cnt, p->stats.im_bytes,
                 p->stats.pm_cnt, p->stats.pm_failures,


### PR DESCRIPTION
- Update sandbox statistics when messages aren't being processed
  allowing the last sample to be flushed