### PR TITLE
Remove the checkpoint reader from the Hindsight config struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(hindsight VERSION 0.10.0 LANGUAGES C)
+project(hindsight VERSION 0.10.1 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hindsight")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})

--- a/src/hs_analysis_plugins.h
+++ b/src/hs_analysis_plugins.h
@@ -38,11 +38,12 @@ struct hs_analysis_plugin {
 };
 
 struct hs_analysis_plugins {
-  hs_analysis_thread  *list;
-  pthread_t           *threads;
-  hs_config           *cfg;
-  int                 thread_cnt;
-  hs_output           output;
+  hs_analysis_thread    *list;
+  pthread_t             *threads;
+  hs_config             *cfg;
+  hs_checkpoint_reader  *cpr;
+  int                   thread_cnt;
+  hs_output             output;
 };
 
 struct hs_analysis_thread {
@@ -63,15 +64,15 @@ struct hs_analysis_thread {
   bool     sample;
 };
 
-void hs_init_analysis_plugins(hs_analysis_plugins *plugins, hs_config *cfg);
+void hs_init_analysis_plugins(hs_analysis_plugins *plugins,
+                              hs_config *cfg,
+                              hs_checkpoint_reader *cpr);
 
 void hs_free_analysis_plugins(hs_analysis_plugins *plugins);
 
 void hs_start_analysis_threads(hs_analysis_plugins *plugins);
 
-void hs_load_analysis_plugins(hs_analysis_plugins *plugins,
-                              const hs_config *cfg,
-                              bool dynamic);
+void hs_load_analysis_plugins(hs_analysis_plugins *plugins, bool dynamic);
 
 void hs_start_analysis_input(hs_analysis_plugins *plugins, pthread_t *t);
 

--- a/src/hs_checkpoint_reader.h
+++ b/src/hs_checkpoint_reader.h
@@ -14,7 +14,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define HS_MAX_PATH 260
 #define HS_MAX_IP_CHECKPOINT 4096
 
 typedef enum {

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -13,9 +13,8 @@
 #include <luasandbox/util/output_buffer.h>
 #include <stdbool.h>
 
-#include "hs_checkpoint_reader.h"
-
 #define HS_EXT_LEN 4
+#define HS_MAX_PATH 260
 
 extern const char *hs_input_dir;
 extern const char *hs_analysis_dir;
@@ -31,7 +30,7 @@ typedef struct hs_sandbox_config
   char *cfg_name;
   char *cfg_lua;
 
-  char *message_matcher; // analysis/output sandbox only
+  char     *message_matcher; // analysis/output sandbox only
   unsigned thread; // analysis sandbox only
   unsigned async_buffer_size; // output sandbox only
 
@@ -39,8 +38,8 @@ typedef struct hs_sandbox_config
   unsigned memory_limit;
   unsigned instruction_limit;
   unsigned ticker_interval;
-  bool preserve_data;
-  bool restricted_headers;
+  bool     preserve_data;
+  bool     restricted_headers;
 } hs_sandbox_config;
 
 typedef struct hs_config
@@ -53,14 +52,15 @@ typedef struct hs_config
   char *analysis_lua_path;
   char *analysis_lua_cpath;
   char *hostname;
+
   unsigned max_message_size;
   unsigned output_size;
   unsigned analysis_threads;
   unsigned backpressure;
   unsigned backpressure_df;
-  bool rm_checkpoint;
-  int pid;
-  hs_checkpoint_reader cp_reader;
+  int      pid;
+  bool     rm_checkpoint;
+
   hs_sandbox_config ipd; // input plugin defaults
   hs_sandbox_config apd; // analysis plugin defaults
   hs_sandbox_config opd; // output plugin defaults

--- a/src/hs_input.h
+++ b/src/hs_input.h
@@ -11,6 +11,7 @@
 
 #include <luasandbox/util/input_buffer.h>
 
+#include "hs_checkpoint_reader.h"
 #include "hs_config.h"
 
 #include <pthread.h>

--- a/src/hs_input_plugins.h
+++ b/src/hs_input_plugins.h
@@ -36,8 +36,9 @@ struct hs_input_plugin {
 };
 
 struct hs_input_plugins {
-  hs_input_plugin **list;
-  hs_config       *cfg;
+  hs_input_plugin       **list;
+  hs_config             *cfg;
+  hs_checkpoint_reader  *cpr;
 
   pthread_mutex_t list_lock;
   int list_cnt;
@@ -46,12 +47,13 @@ struct hs_input_plugins {
   hs_output output;
 };
 
-void hs_init_input_plugins(hs_input_plugins *plugins, hs_config *cfg);
+void hs_init_input_plugins(hs_input_plugins *plugins,
+                           hs_config *cfg,
+                           hs_checkpoint_reader *cpr);
 
 void hs_free_input_plugins(hs_input_plugins *plugins);
 
-void hs_load_input_plugins(hs_input_plugins *plugins, const hs_config *cfg,
-                           bool dynamic);
+void hs_load_input_plugins(hs_input_plugins *plugins, bool dynamic);
 
 void hs_stop_input_plugins(hs_input_plugins *plugins);
 

--- a/src/hs_output.h
+++ b/src/hs_output.h
@@ -9,6 +9,7 @@
 #ifndef hs_output_h_
 #define hs_output_h_
 
+#include "hs_checkpoint_reader.h"
 #include "hs_config.h"
 
 #include <luasandbox/lua.h>

--- a/src/hs_output_plugins.h
+++ b/src/hs_output_plugins.h
@@ -32,7 +32,7 @@ struct hs_output_plugin {
   lsb_heka_sandbox    *hsb;
   lsb_message_matcher *mm;
   hs_output_plugins   *plugins;
-  uintptr_t  sequence_id;
+  uintptr_t           sequence_id;
   lsb_running_stats   mms;
   lsb_heka_stats      stats;
   int                 ticker_interval;
@@ -54,8 +54,9 @@ struct hs_output_plugin {
 };
 
 struct hs_output_plugins {
-  hs_output_plugin **list;
-  hs_config *cfg;
+  hs_output_plugin      **list;
+  hs_config             *cfg;
+  hs_checkpoint_reader  *cpr;
 
   int list_cnt;
   int list_cap;
@@ -63,13 +64,13 @@ struct hs_output_plugins {
   pthread_mutex_t list_lock;
 };
 
-void hs_init_output_plugins(hs_output_plugins *plugins, hs_config *cfg);
+void hs_init_output_plugins(hs_output_plugins *plugins,
+                            hs_config *cfg,
+                            hs_checkpoint_reader *cpr);
 
 void hs_free_output_plugins(hs_output_plugins *plugins);
 
-void hs_load_output_plugins(hs_output_plugins *plugins,
-                            const hs_config *cfg,
-                            bool dynamic);
+void hs_load_output_plugins(hs_output_plugins *plugins, bool dynamic);
 
 void hs_stop_output_plugins(hs_output_plugins *plugins);
 


### PR DESCRIPTION
- output the fully merged configuration to disk for the admin UI