### PR TITLE
travis: tag docker image as 'latest'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
             if [ ! -z "$TRAVIS_TAG" ]; then
                 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
                 docker tag app:build mozilla/hindsight:${TRAVIS_TAG}
-                docker push mozilla/hindsight:${TRAVIS_TAG}
+                docker tag app:build mozilla/hindsight:latest
+                docker push mozilla/hindsight:latest
                 docker logout
             fi
         fi


### PR DESCRIPTION
The `docker pull` commands looks for an image tagged `latest` by default, and fails if not found. This change ensures the most recent release of the container is tagged as `latest` when pushing it to dockerhub.