### PR TITLE
Increase max upper bound for inject_message limits

### DIFF
--- a/src/hs_analysis_plugins.h
+++ b/src/hs_analysis_plugins.h
@@ -36,9 +36,9 @@ struct hs_analysis_plugin {
   int                 ticker_interval;
   int                 pm_delta_cnt;
   bool                shutdown_terminate;
-  unsigned char       im_limit;
-  unsigned char       pm_im_limit;
-  unsigned char       te_im_limit;
+  int                 im_limit;
+  int                 pm_im_limit;
+  int                 te_im_limit;
   time_t              ticker_expires;
 };
 

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -201,34 +201,6 @@ static int get_unsigned_int(lua_State *L, int idx, const char *name,
 }
 
 
-static int get_unsigned_char(lua_State *L, int idx, const char *name,
-                             unsigned char *val)
-{
-  lua_getfield(L, idx, name);
-  int t = lua_type(L, -1);
-  double d;
-  switch (t) {
-  case LUA_TNUMBER:
-    d = lua_tonumber(L, -1);
-    if (d < 0 || d > UCHAR_MAX) {
-      lua_pushfstring(L, "%s must be an unsigned char", name);
-      return 1;
-    }
-    *val = (unsigned char)d;
-    break;
-  case LUA_TNIL:
-    break; // use the default
-  default:
-    lua_pushfstring(L, "%s must be set to a number", name);
-    return 1;
-    break;
-  }
-  remove_item(L, idx, name);
-
-  return 0;
-}
-
-
 static int get_bool_item(lua_State *L, int idx, const char *name, bool *val)
 {
   lua_getfield(L, idx, name);

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -279,10 +279,10 @@ static int load_sandbox_defaults(lua_State *L,
   }
 
   if (strcmp(key, cfg_sb_apd) == 0) {
-    if (get_unsigned_char(L, 1, cfg_sb_pm_im_limit, &cfg->pm_im_limit)) {
+    if (get_unsigned_int(L, 1, cfg_sb_pm_im_limit, &cfg->pm_im_limit)) {
       return 1;
     }
-    if (get_unsigned_char(L, 1, cfg_sb_te_im_limit, &cfg->te_im_limit)) {
+    if (get_unsigned_int(L, 1, cfg_sb_te_im_limit, &cfg->te_im_limit)) {
       return 1;
     }
   }
@@ -509,9 +509,9 @@ bool hs_load_sandbox_config(const char *dir,
   if (type == 'a') {
     ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_thread,
                            &cfg->thread);
-    ret = get_unsigned_char(L, LUA_GLOBALSINDEX, cfg_sb_pm_im_limit,
+    ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_pm_im_limit,
                             &cfg->pm_im_limit);
-    ret = get_unsigned_char(L, LUA_GLOBALSINDEX, cfg_sb_te_im_limit,
+    ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_te_im_limit,
                             &cfg->te_im_limit);
     if (ret) goto cleanup;
   }

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -47,8 +47,8 @@ typedef struct hs_sandbox_config
   bool shutdown_terminate;
   bool rm_cp_terminate;   // output sandbox only
 
-  unsigned char pm_im_limit; // analysis sandbox only
-  unsigned char te_im_limit; // analysis sandbox only
+  unsigned pm_im_limit; // analysis sandbox only
+  unsigned te_im_limit; // analysis sandbox only
 } hs_sandbox_config;
 
 typedef struct hs_config


### PR DESCRIPTION
We've been building a log aggregator, and by its nature, it sometimes needs to flush a lot of accumulated state. We're hitting the `timer_event_inject_limit` all the time because of this, and setting it to `0` just means `inject_message` is disallowed.

This PR simply bumps `timer_event_inject_limit` and `process_message_inject_limit` from a `char` to an `int` to allow for (much) higher values in the configuration.
