### PR TITLE
Build docker image using Circle-CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,7 @@ RUN yum -y update && \
 USER app
 WORKDIR /app
 
-RUN sudo yum -y install wget && \
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm && \
-    sudo rpm -ivh epel-release-7-9.noarch.rpm && \
-    rm epel-release-7-9.noarch.rpm && \
+RUN sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm && \
     sudo yum -y install lua-devel luarocks cmake3 make clang gcc git rpm-build sudo && \
     sudo ln -s /usr/bin/cmake3 /usr/local/bin/cmake && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,11 @@ RUN sudo yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-re
     sudo ln -s /usr/bin/cmake3 /usr/local/bin/cmake && \
 
     # Install confluent 3.1 for centos 7 for librdkafka-devel
-    echo [confluent] > confluent.repo && \
-    echo name=confluent >> confluent.repo && \
-    echo baseurl=http://packages.confluent.io/rpm/3.1/7 >> confluent.repo && \
-    echo gpgcheck=1 >> confluent.repo && \
-    echo gpgkey=http://packages.confluent.io/rpm/3.1/archive.key >> confluent.repo && \
-    sudo mv confluent.repo /etc/yum.repos.d && \
+    echo -e "[confluent]\n\
+name=confluent\n\
+baseurl=http://packages.confluent.io/rpm/3.1/7\n\
+gpgcheck=1\n\
+gpgkey=http://packages.confluent.io/rpm/3.1/archive.key\n" | sudo tee /etc/yum.repos.d/confluent.repo && \
 
     # Build the lua sandbox & extensions
     cd /app/src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ gpgkey=http://packages.confluent.io/rpm/3.1/archive.key\n" | sudo tee /etc/yum.r
         make packages; \
     } && \
     build_function="build_lsbe" main && \
-    sudo rpm -ivh /app/src/lua_sandbox_extensions/release/luasandbox*Linux.rpm && \
+    sudo yum install -y /app/src/lua_sandbox_extensions/release/luasandbox*Linux.rpm && \
 
     # Build hindsight
     cd /app/src/hindsight && \
@@ -56,7 +56,7 @@ gpgkey=http://packages.confluent.io/rpm/3.1/archive.key\n" | sudo tee /etc/yum.r
     make && \
     ctest3 && \
     cpack3 -G RPM && \
-    sudo rpm -ivh /app/src/hindsight/release/hindsight*Linux.rpm && \
+    sudo yum install -y /app/src/hindsight/release/hindsight*Linux.rpm && \
 
     # Setup run directory
     cd /app && \
@@ -74,7 +74,7 @@ gpgkey=http://packages.confluent.io/rpm/3.1/archive.key\n" | sudo tee /etc/yum.r
 
     # cleanup
     rm -rf /app/src && \
-    sudo yum -y remove cmake3 make clang git rpm-build && \
+    sudo yum -y remove cmake3 make clang git rpm-build c++-compiler librdkafka-devel openssl-devel postgresql-devel systemd-devel zlib-devel  && \
     sudo yum -y autoremove && \
     sudo yum -y clean all
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,70 @@
+# These environment variables must be set in CircleCI UI
+#
+# DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
+# DOCKER_EMAIL   - login info for docker hub
+# DOCKER_USER
+# DOCKER_PASS
+#
+machine:
+  services:
+    - docker
+
+dependencies:
+  cache_directories:
+    - "~/docker"
+
+  pre:
+    - sudo apt-get update; sudo apt-get install pigz
+
+  override:
+    - docker info
+
+    # Build the container, using Circle's Docker cache. Only use 1 image per
+    # day to keep the cache size down.
+    - I="image-$(date +%j).gz"; if [[ -e ~/docker/$I ]]; then echo "Loading $I"; pigz -d -c ~/docker/$I | docker load; fi
+
+    # create a version.json
+    - >
+        printf '{"name":"%s","commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
+        "hindsight",
+        "$CIRCLE_SHA1"
+        "$CIRCLE_TAG"
+        "mozilla-services"
+        "$CIRCLE_PROJECT_REPONAME"
+        "$CIRCLE_BUILD_URL"
+        > version.json
+
+    # build the actual deployment container
+    - docker build --pull -t app .
+
+    # write the sha256 sum to an artifact to make image verification easier
+    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
+
+    # Clean up any old images; save the new one.
+    - I="image-$(date +%j).gz"; mkdir -p ~/docker; rm ~/docker/*; docker save app | pigz --fast -c > ~/docker/$I; ls -l ~/docker
+
+test:
+  override:
+    -  'true'
+
+# appropriately tag and push the container to dockerhub
+deployment:
+  hub_latest:
+    branch: "master"
+    commands:
+      - "[ ! -z $DOCKERHUB_REPO ]"
+      - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
+      - "docker images"
+      - "docker tag app ${DOCKERHUB_REPO}:latest"
+      - "docker push ${DOCKERHUB_REPO}:latest"
+
+  hub_releases:
+    # push all tags
+    tag: /.*/
+    commands:
+      - "[ ! -z $DOCKERHUB_REPO ]"
+      - "docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS"
+      - "echo ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+      - "docker tag app ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+      - "docker images"
+      - "docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}"


### PR DESCRIPTION
As part of project-manatee we would like to deploy hindsight into our environments via a docker container. As with most of our projects in cloud-services we use Circle-CI to build the docker image and push it into DockerHub. This PR add the Circle-CI configuration and also makes a few minor changes to the Dockerfile.

r? 