### PR TITLE
WIP Introduce support for pinning specific analysis threads to a logical CPU core

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,7 @@ input_defaults = {
 
 analysis_defaults = {
   -- see: Default Sandbox Configuration Variables
+  -- cpu_affinity           = false
 }
 
 output_defaults = {
@@ -125,6 +126,8 @@ output_defaults = {
 * **timer_event_inject_limit** - the maximum number of messages the
   `timer_event` function can inject in a single invocation (count,
   default 10).
+
+* **cpu_affinity** - if analysis threads should be pinned to a logical CPU core (bool, default false)
 
 #### Default Output Sandbox Configuration Variables
 

--- a/src/hs_analysis_plugins.h
+++ b/src/hs_analysis_plugins.h
@@ -39,6 +39,7 @@ struct hs_analysis_plugin {
   unsigned            im_limit;
   unsigned            pm_im_limit;
   unsigned            te_im_limit;
+  bool                cpu_affinity;
   time_t              ticker_expires;
 };
 
@@ -73,6 +74,7 @@ struct hs_analysis_thread {
   int       utilization;
   bool      stop;
   bool      sample;
+  bool      cpu_affinity;
 #ifdef HINDSIGHT_CLI
   bool      terminated;
 #endif

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -58,6 +58,7 @@ static const char *cfg_sb_restricted_headers = "restricted_headers";
 static const char *cfg_sb_filename = "filename";
 static const char *cfg_sb_ticker_interval = "ticker_interval";
 static const char *cfg_sb_thread = "thread";
+static const char *cfg_sb_cpu_affinity = "cpu_affinity";
 static const char *cfg_sb_async_buffer = "async_buffer_size";
 static const char *cfg_sb_matcher = "message_matcher";
 static const char *cfg_sb_shutdown_terminate = "shutdown_on_terminate";
@@ -75,6 +76,7 @@ static void init_sandbox_config(hs_sandbox_config *cfg)
   cfg->message_matcher = NULL;
 
   cfg->thread = UINT_MAX;
+  cfg->cpu_affinity = false;
   cfg->async_buffer_size = 0;
   cfg->output_limit = 1024 * 64;
   cfg->memory_limit = 1024 * 1024 * 8;
@@ -519,6 +521,8 @@ bool hs_load_sandbox_config(const char *dir,
   if (type == 'a') {
     ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_thread,
                            &cfg->thread);
+    ret = get_bool_item(L, LUA_GLOBALSINDEX, cfg_sb_cpu_affinity,
+                         &cfg->cpu_affinity);
     ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_pm_im_limit,
                             &cfg->pm_im_limit);
     ret = get_unsigned_int(L, LUA_GLOBALSINDEX, cfg_sb_te_im_limit,
@@ -843,6 +847,8 @@ bool hs_output_runtime_cfg(lsb_output_buffer *ob, char type, const hs_config *cf
 
   if (type == 'a') {
     lsb_outputf(ob, "thread = %u\n", sbc->thread);
+    lsb_outputf(ob, "cpu_affinity = %s\n",
+              sbc->cpu_affinity ? "true" : "false");
     lsb_outputf(ob, "process_message_inject_limit = %u\n", sbc->pm_im_limit);
     lsb_outputf(ob, "timer_event_inject_limit = %u\n", sbc->te_im_limit);
   }

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -36,6 +36,7 @@ typedef struct hs_sandbox_config
   char *message_matcher; // analysis/output sandbox only
 
   unsigned thread; // analysis sandbox only
+  bool cpu_affinity; // analysis sandbox only
   unsigned async_buffer_size; // output sandbox only
   unsigned output_limit;
   unsigned memory_limit;


### PR DESCRIPTION
References https://eli.thegreenplace.net/2016/c11-threads-affinity-and-hyperthreading/ with hyperthread behaviour seen in our environment and http://man7.org/linux/man-pages/man2/sched_setaffinity.2.html

### to flesh out

* currently logical CPU affinity == the assigned analysis thread id (0, 1, 2 etc.) and a `cpu_affinity = true` directive in the plugin config would pin to that. Maybe that's not a great default
* What config would look like for a "fatter" plugin we want a dedicated core without switching for could like:
```
thread = 0 -- explicitly define this here to schedule on analysis thread 0
cpu_affinity = true -- always pin to logical core one as well
```

That way auxiliary / less important plugins can still migrate between remaining cores, but we guarantee resources for the most important ones.

@Shopify/moneyscale