### PR TITLE
link OpenSSL shared object, configure threading callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
-project(hindsight VERSION 0.15.1 LANGUAGES C)
+project(hindsight VERSION 0.15.2 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hindsight")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
@@ -24,6 +24,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(mozsvc)
 
 find_package(luasandbox 1.3 REQUIRED CONFIG)
+if (NOT WITHOUT_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+  add_definitions(-DWITH_OPENSSL)
+endif()
 include(GNUInstallDirs)
 
 if(CMAKE_HOST_UNIX)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ running instance here: [hsadmin](https://hsadmin.trink.com/))
 * Clang 3.1 or GCC 4.7+
 * CMake (3.6+) - http://cmake.org/cmake/resources/software.html
 * lua_sandbox (1.2.3+) - https://github.com/mozilla-services/lua_sandbox
+* OpenSSL (1.0.x+, optional)
 
 ### CMake Build Instructions
 
@@ -43,6 +44,11 @@ running instance here: [hsadmin](https://hsadmin.trink.com/))
     cpack -G TGZ # (DEB|RPM|ZIP)
 
     # Cross platform support is planned but not supported yet
+
+By default hindsight is linked against OpenSSL and configured to set locking callbacks in the
+library to ensure proper threaded operation. If this functionality is not desired the cmake
+build option `-DWITHOUT_OPENSSL=true` can be used to disable this, for example if you are not
+using any sandboxes/modules that make use of OpenSSL and do not want the dependency.
 
 ## Releases
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,17 +13,17 @@ hs_input_plugins.c
 hs_logger.c
 hs_output.c
 hs_output_plugins.c
+hs_sslutil.c
 hs_util.c
 )
-
-set(HINDSIGHT_LIBS
-${LUASANDBOX_LIBRARIES}
-${UNIX_LIBRARIES})
 
 add_executable(hindsight ${HINDSIGHT_SRC})
 set(HINDSIGHT_LIBS
 ${LUASANDBOX_LIBRARIES}
 ${UNIX_LIBRARIES})
+if (NOT WITHOUT_OPENSSL)
+  set(HINDSIGHT_LIBS ${HINDSIGHT_LIBS} ${OPENSSL_LIBRARIES})
+endif()
 
 target_link_libraries(hindsight ${HINDSIGHT_LIBS})
 

--- a/src/hindsight.c
+++ b/src/hindsight.c
@@ -27,6 +27,7 @@
 #include "hs_input_plugins.h"
 #include "hs_logger.h"
 #include "hs_output_plugins.h"
+#include "hs_sslutil.h"
 
 
 static const char g_module[] = "hindsight";
@@ -94,6 +95,16 @@ int main(int argc, char *argv[])
     }
   }
   hs_init_log(loglevel);
+
+#ifdef WITH_OPENSSL
+  if (hs_sslcallback_init()) {
+    // openssl < 1.1 requires locking callbacks in a multi-threaded environment,
+    // install those here so sandboxes that make use of openssl can utilize the
+    // already established set of locking callbacks
+    fprintf(stderr, "openssl locking callback initialization failed\n");
+    return EXIT_FAILURE;
+  }
+#endif
 
   hs_config cfg;
   if (hs_load_config(argv[1], &cfg)) {

--- a/src/hs_sslutil.c
+++ b/src/hs_sslutil.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** @brief Hindsight sslutil implementation @file */
+
+#include "hs_util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#ifdef WITH_OPENSSL
+#include <openssl/crypto.h>
+
+#define OPENSSL_REQUIRES_LOCKS (OPENSSL_VERSION_NUMBER < 0x10100003L)
+
+#if OPENSSL_REQUIRES_LOCKS
+static pthread_mutex_t *sslmtxlist;
+
+static unsigned long hs_sslcallback_idfunc()
+{
+  return ((unsigned long)pthread_self());
+}
+
+static void hs_sslcallback_lockfunc(int m, int n, const char *f __attribute__((unused)),
+  int line __attribute__((unused)))
+{
+  if (m & CRYPTO_LOCK)
+    pthread_mutex_lock(&sslmtxlist[n]);
+  else
+    pthread_mutex_unlock(&sslmtxlist[n]);
+}
+
+static int hs_sslcallback_initlocks()
+{
+  int i;
+
+  sslmtxlist = (pthread_mutex_t *)malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
+  if (!sslmtxlist)
+    return 1;
+
+  for (i = 0; i < CRYPTO_num_locks(); i++)
+    pthread_mutex_init(&(sslmtxlist[i]), NULL);
+
+  CRYPTO_set_id_callback(hs_sslcallback_idfunc);
+  CRYPTO_set_locking_callback(hs_sslcallback_lockfunc);
+  return 0;
+}
+#endif
+
+
+int hs_sslcallback_init()
+{
+#if OPENSSL_REQUIRES_LOCKS
+  if (hs_sslcallback_initlocks())
+    return 1;
+#endif
+  return 0;
+}
+#endif

--- a/src/hs_sslutil.h
+++ b/src/hs_sslutil.h
@@ -1,0 +1,26 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** Hindsight utility functions for sandboxes using OpenSSL @file */
+
+#ifndef hs_sslutil_h_
+#define hs_sslutil_h_
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "hs_config.h"
+
+/**
+ * Bootstrap OpenSSL threading callbacks
+ *
+ * @return 0 if callback initialization succeeded
+ */
+int hs_sslcallback_init();
+
+#endif


### PR DESCRIPTION
Various sandboxes and modules hindsight makes use of require OpenSSL,
including modules such as the lua_sandbox_extensions aws, ssl, and
openssl modules.

For OpenSSL to execute correctly within a threaded process callbacks
need to be installed to support platform specific locking and thread
identification.

Prior to this change it was highly dependent on the modules to decide to
implement the callbacks, e.g., some would (aws, openssl) some would not
(ssl). In cases where the modules implemented the callback, the function
pointer would typically be set to a function within the mapped shared
object of a given module.

This causes strange behavior if a module is unmapped from hindsight, as
a configured callback function pointer may no longer be valid
anymore.

This change links OpenSSL with hindsight and configures callbacks in
main to ensure they are configured and will point to code that will be
available for the lifetime of the process.