### PR TITLE
Issue 192 - Fix FPE on the message per second estimate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
-project(hindsight VERSION 0.15.4 LANGUAGES C)
+project(hindsight VERSION 0.15.5 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hindsight")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})

--- a/src/hs_checkpoint_writer.c
+++ b/src/hs_checkpoint_writer.c
@@ -164,7 +164,8 @@ static void input_stats(hs_checkpoint_writer *cpw, hs_checkpoint_reader *cpr,
 static int get_max_mps(long long tt, int amps, int max_mps)
 {
   if (tt && amps) {
-    int emps = 1000000000LL / (tt / amps) + 1;
+    int tmps = tt / amps;
+    int emps = tmps ? 1000000000LL / tmps + 1 : 1;
     if (emps > max_mps) {
       max_mps = emps;
     }


### PR DESCRIPTION
This will prevent the FPE but the underlying issue of why the
total time and number of messages processed ratio is so out of
alignment needs to be investigated.