### PR TITLE
upgrade links from http to https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
 project(hindsight VERSION 0.16.0 LANGUAGES C)

--- a/LICENSE
+++ b/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ is stable and changes infrequently.  There is also a [Hindsight Administration U
 available for monitoring, debugging and plugin management (you can check out a
 running instance here: [hsadmin](https://hsadmin.trink.com/))
 
-* [Full Documentation](http://mozilla-services.github.io/hindsight)
+* [Full Documentation](https://mozilla-services.github.io/hindsight)
 * Support
     * Chat: [Matrix](https://chat.mozilla.org/#/room/#hindsight:mozilla.org)
     * Mailing list: https://mail.mozilla.org/listinfo/hindsight
@@ -26,7 +26,7 @@ running instance here: [hsadmin](https://hsadmin.trink.com/))
 ### Prerequisites
 
 * Clang 3.1 or GCC 4.7+
-* CMake (3.6+) - http://cmake.org/cmake/resources/software.html
+* CMake (3.6+) - https://cmake.org/cmake/resources/software.html
 * lua_sandbox (1.2.3+) - https://github.com/mozilla-services/lua_sandbox
 * OpenSSL (1.0.x+, optional)
 

--- a/benchmarks/run/analysis/counter.lua
+++ b/benchmarks/run/analysis/counter.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 local cnt = 0
 

--- a/benchmarks/run/input/input_test.lua
+++ b/benchmarks/run/input/input_test.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 require "io"
 

--- a/benchmarks/run/output/counter.lua
+++ b/benchmarks/run/output/counter.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 local cnt = 0
 

--- a/benchmarks/run_hsr/input/readmsg.lua
+++ b/benchmarks/run_hsr/input/readmsg.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 require "io"
 require "string"

--- a/benchmarks/run_hsr/input/tcpinput.lua
+++ b/benchmarks/run_hsr/input/tcpinput.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 require "coroutine"
 local socket = require "socket"

--- a/benchmarks/run_hsr/output/tcpoutput.lua
+++ b/benchmarks/run_hsr/output/tcpoutput.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 local socket = require "socket"
 

--- a/benchmarks/run_multiple/input/input_test.lua
+++ b/benchmarks/run_multiple/input/input_test.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 require "io"
 

--- a/cmake/mozsvc.cmake
+++ b/cmake/mozsvc.cmake
@@ -1,10 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 if(MSVC)
-    # Predefined Macros: http://msdn.microsoft.com/en-us/library/b0084kay.aspx
-    # Compiler options: http://msdn.microsoft.com/en-us/library/fwkeyyhe.aspx
+    # Predefined Macros: https://msdn.microsoft.com/en-us/library/b0084kay.aspx
+    # Compiler options: https://msdn.microsoft.com/en-us/library/fwkeyyhe.aspx
 
     # set a high warning level and treat them as errors
     set(CMAKE_C_FLAGS           "/W3 /WX")
@@ -18,7 +18,7 @@ if(MSVC)
     set(CPACK_GENERATOR         "NSIS")
 else()
     # Predefined Macros: clang|gcc -dM -E -x c /dev/null
-    # Compiler options: http://gcc.gnu.org/onlinedocs/gcc/Invoking-GCC.html#Invoking-GCC
+    # Compiler options: https://gcc.gnu.org/onlinedocs/gcc/Invoking-GCC.html#Invoking-GCC
     set(CMAKE_C_FLAGS   "-std=c99 -pedantic -Werror -Wno-error=deprecated -Wall -Wextra -fPIC")
     set(CMAKE_C_FLAGS_DEBUG     "-g")
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,12 @@ So how much lighter and faster? see: [Performance](performance.md)
 * [Architecture](architecture.md)
 * [Configuration](configuration.md)
 * [Command Line Version](hindsight_cli.md)
-* [Heka Sandbox Documentation](http://mozilla-services.github.io/lua_sandbox/heka/index.html)
-* [Sandbox Extensions Documentation](http://mozilla-services.github.io/lua_sandbox_extensions/index.html)
+* [Heka Sandbox Documentation](https://mozilla-services.github.io/lua_sandbox/heka/index.html)
+* [Sandbox Extensions Documentation](https://mozilla-services.github.io/lua_sandbox_extensions/index.html)
 
 ### Differences from Heka
 
-1. [Sandbox API Differences](http://mozilla-services.github.io/lua_sandbox/heka/index.html#sandbox-api-changes-from-the-go-heka-sandbox)
+1. [Sandbox API Differences](https://mozilla-services.github.io/lua_sandbox/heka/index.html#sandbox-api-changes-from-the-go-heka-sandbox)
 1. The message matcher now uses Lua string match patterns instead of RE2
 expressions.
 1. Looping messages in Heka, injecting messages back to an earlier point in the

--- a/docs/tutorials/using_decoders_with_input_plugins.md
+++ b/docs/tutorials/using_decoders_with_input_plugins.md
@@ -19,7 +19,7 @@ configurations discussed here are independent from the input plugin being used.
 
 ## Definition of Terms
 
-* [Input Plugin](http://mozilla-services.github.io/lua_sandbox/heka/input.html) -
+* [Input Plugin](https://mozilla-services.github.io/lua_sandbox/heka/input.html) -
   A piece of Lua code that loads data into Hindsight
 * Decoders/Sub-decoders - Zero or more stages during the input process where the
   raw data is transformed into a more useful form
@@ -44,7 +44,7 @@ This is an example of a basic syslog decoder that extracts the header
 information (timestamp, hostname, pid, programname) and the message string. The
 only thing required to configure the basic syslog decoder is the template
 configuration specified in the
-[rsyslog.conf](http://rsyslog-5-8-6-doc.neocities.org/rsyslog_conf_templates.html)
+[rsyslog.conf](https://rsyslog-5-8-6-doc.neocities.org/rsyslog_conf_templates.html)
 file. The template below is the RSYSLOG_TraditionalFileFormat without the new
 line at the end since that is consumed by the file input. The Uuid (type 4
 random) and Logger (input plugin name) are added to the output by Hindsight.

--- a/gen_gh_pages.lua
+++ b/gen_gh_pages.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 require "os"
 require "io"
@@ -16,8 +16,8 @@ local function output_menu(output_dir, version)
 * [Configuration](configuration.md)
 * [Command Line Version](hindsight_cli.md)
 * [Execution Profiling](hindsight_timer_report.md)
-* [Heka Sandbox Documentation](http://mozilla-services.github.io/lua_sandbox/heka/index.html)
-* [Sandbox Extensions Documentation](http://mozilla-services.github.io/lua_sandbox_extensions/index.html)
+* [Heka Sandbox Documentation](https://mozilla-services.github.io/lua_sandbox/heka/index.html)
+* [Sandbox Extensions Documentation](https://mozilla-services.github.io/lua_sandbox_extensions/index.html)
 
 ### Tutorials
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 set(HINDSIGHT_SRC
 hindsight.c

--- a/src/hindsight.c
+++ b/src/hindsight.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight main executable @file */
 

--- a/src/hs_analysis_plugins.c
+++ b/src/hs_analysis_plugins.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight analysis plugin loader @file */
 

--- a/src/hs_analysis_plugins.h
+++ b/src/hs_analysis_plugins.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight analysis sandbox loader @file */
 

--- a/src/hs_checkpoint_reader.c
+++ b/src/hs_checkpoint_reader.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight checkpoint_reader implementation @file */
 

--- a/src/hs_checkpoint_reader.h
+++ b/src/hs_checkpoint_reader.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight checkpoint reader functions and structures @file */
 

--- a/src/hs_checkpoint_writer.c
+++ b/src/hs_checkpoint_writer.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight checkpoint_writer implementation @file */
 

--- a/src/hs_checkpoint_writer.h
+++ b/src/hs_checkpoint_writer.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight checkpoint functions and structures @file */
 

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight configuration implementation @file */
 

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight main configuration module @file */
 

--- a/src/hs_input.c
+++ b/src/hs_input.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight input implementation @file */
 

--- a/src/hs_input.h
+++ b/src/hs_input.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight input facility @file */
 

--- a/src/hs_input_plugins.c
+++ b/src/hs_input_plugins.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight configuration loader @file */
 #define _GNU_SOURCE

--- a/src/hs_input_plugins.h
+++ b/src/hs_input_plugins.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight input plugins @file */
 

--- a/src/hs_logger.c
+++ b/src/hs_logger.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight logging implementation @file */
 

--- a/src/hs_logger.h
+++ b/src/hs_logger.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight logging facility @file */
 

--- a/src/hs_output.c
+++ b/src/hs_output.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight output implementation @file */
 

--- a/src/hs_output.h
+++ b/src/hs_output.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight output functions and structures @file */
 

--- a/src/hs_output_plugins.c
+++ b/src/hs_output_plugins.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight output plugin loader @file */
 

--- a/src/hs_output_plugins.h
+++ b/src/hs_output_plugins.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight output sandbox loader @file */
 

--- a/src/hs_sslutil.c
+++ b/src/hs_sslutil.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight sslutil implementation @file */
 

--- a/src/hs_sslutil.h
+++ b/src/hs_sslutil.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight utility functions for sandboxes using OpenSSL @file */
 

--- a/src/hs_util.c
+++ b/src/hs_util.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight util implementation @file */
 

--- a/src/hs_util.h
+++ b/src/hs_util.h
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** Hindsight utility functions @file */
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 configure_file(test.h.in test.h ESCAPE_QUOTES)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/src/test/sandbox/analysis.lua
+++ b/src/test/sandbox/analysis.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 local function test_array(a)
     assert(type(a) == "table", type(a))

--- a/src/test/sandbox/input.lua
+++ b/src/test/sandbox/input.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 function process_message()
     assert(read_config("cfg_name") == "input")

--- a/src/test/sandbox/output.lua
+++ b/src/test/sandbox/output.lua
@@ -1,6 +1,6 @@
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
--- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 function process_message()
     assert(read_config("cfg_name") == "output")

--- a/src/test/test.h.in
+++ b/src/test/test.h.in
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight unit tests macros @file */
 

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -2,7 +2,7 @@
 /* vim: set ts=2 et sw=2 tw=80: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /** @brief Hindsight unit tests @file */
 


### PR DESCRIPTION
all these domains support https, so there's no reason to use http links.